### PR TITLE
Add RateLimiting trait

### DIFF
--- a/META.json
+++ b/META.json
@@ -4,7 +4,7 @@
       "Marc Mims <marc@questright.com>"
    ],
    "dynamic_config" : 0,
-   "generated_by" : "Dist::Zilla version 6.008, CPAN::Meta::Converter version 2.150001",
+   "generated_by" : "Dist::Zilla version 6.011, CPAN::Meta::Converter version 2.150010",
    "license" : [
       "perl_5"
    ],
@@ -115,6 +115,10 @@
          "file" : "lib/Twitter/API/Trait/NormalizeBooleans.pm",
          "version" : "0.0113"
       },
+      "Twitter::API::Trait::RateLimiting" : {
+         "file" : "lib/Twitter/API/Trait/RateLimiting.pm",
+         "version" : "0.0113"
+      },
       "Twitter::API::Trait::RetryOnError" : {
          "file" : "lib/Twitter/API/Trait/RetryOnError.pm",
          "version" : "0.0113"
@@ -140,11 +144,13 @@
    "version" : "0.0113",
    "x_contributors" : [
       "Andrew Grangaard <granny-github@ofb.net>",
+      "Dave Jacoby <jacoby.david@gmail.com>",
       "Desmond Daignault <nawglan@cpan.org>",
       "Karen Etheridge <ether@cpan.org>",
       "Marc Mims <marc@moz.com>",
-      "Mohammad S Anwar <mohammad.anwar@yahoo.com>"
+      "Mohammad S Anwar <mohammad.anwar@yahoo.com>",
+      "Rob Hoelz <rob@hoelz.ro>"
    ],
-   "x_serialization_backend" : "Cpanel::JSON::XS version 3.0225"
+   "x_serialization_backend" : "Cpanel::JSON::XS version 3.0239"
 }
 

--- a/lib/Twitter/API/Trait/RateLimiting.pm
+++ b/lib/Twitter/API/Trait/RateLimiting.pm
@@ -1,0 +1,69 @@
+package Twitter::API::Trait::RateLimiting;
+# ABSTRACT: Automatically sleep as needed to handle rate limiting
+
+use Moo::Role;
+use HTTP::Status qw(HTTP_TOO_MANY_REQUESTS);
+use namespace::clean;
+
+=attr rate_limit_sleep_code
+
+A coderef, called to implement sleeping.  It takes a single parameter -
+the number of seconds to sleep.  The default implementation is:
+
+    sub { sleep shift }
+
+=cut
+
+has rate_limit_sleep_code => (
+    is      => 'rw',
+    default => sub {
+        sub { sleep shift };
+    },
+);
+
+around send_request => sub {
+    my $orig = shift;
+    my $self = shift;
+
+    my $res = $self->$orig(@_);
+
+    while($res->code == HTTP_TOO_MANY_REQUESTS) {
+        my $sleep_time = $res->header('x-rate-limit-reset') - time;
+        $self->rate_limit_sleep_code->($sleep_time);
+
+        $res = $self->$orig(@_);
+    }
+
+    return $res;
+};
+
+1;
+
+__END__
+
+=pod
+
+=head1 SYNOPSIS
+
+    use Twitter::API;
+
+    my $client = Twitter::API->new_with_options(
+        traits => [ qw/ApiMethods RateLimiting/ ],
+        %other_options,
+    );
+
+    # Use $client as normal
+
+=head1 DESCRIPTION
+
+Twitter's API implements rate limiting in a 15-minute window, and
+will serve up an HTTP 429 error if the rate limit is exceeded for
+a window.  Applying this trait will give L<Twitter::API> the ability
+to automatically sleep as much as is needed and then retry a request
+instead of simply throwing an exception.
+
+=head1 SEE ALSO
+
+L<https://developer.twitter.com/en/docs/basics/rate-limiting>
+
+=cut

--- a/t/trait/rate-limiting.t
+++ b/t/trait/rate-limiting.t
@@ -8,7 +8,7 @@ use Test::Spec;
 
 BEGIN {
     my $time = 1_500_000_000;
-    *CORE::GLOBAL::time = sub :prototype() {
+    *CORE::GLOBAL::time = sub () {
         my ( $caller ) = caller();
         if($caller eq 'main' || $caller =~ /^Twitter::API/) {
             return $time++;

--- a/t/trait/rate-limiting.t
+++ b/t/trait/rate-limiting.t
@@ -1,0 +1,150 @@
+#!perl
+use 5.14.1;
+use warnings;
+use HTTP::Status qw(HTTP_TOO_MANY_REQUESTS);
+use HTTP::Response;
+use Test::Fatal;
+use Test::Spec;
+
+BEGIN {
+    my $time = 1_500_000_000;
+    *CORE::GLOBAL::time = sub :prototype() {
+        my ( $caller ) = caller();
+        if($caller eq 'main' || $caller =~ /^Twitter::API/) {
+            return $time++;
+        } else {
+            return CORE::time();
+        }
+    };
+}
+
+use Twitter::API;
+
+sub new_client {
+    my $limit = shift;
+    my $exception_info;
+
+    if(@_) {
+        $exception_info = shift;
+    } else {
+        $exception_info = [ HTTP_TOO_MANY_REQUESTS, 'Rate Limit Exceeded',
+            'x-rate-limit-reset' => time + 900 ];
+    }
+
+    my $remaining = $limit;
+
+    my $user_agent = mock();
+    $user_agent->stubs(request => sub {
+        if(!defined($remaining) || $remaining-- > 0 ) {
+            HTTP::Response->new(200, 'OK');
+        } else {
+            $remaining = $limit;
+
+            my ( $code, $reason, %headers ) = @$exception_info;
+
+            my $res = HTTP::Response->new($code, $reason);
+            for my $name (keys %headers) {
+                $res->header($name, $headers{$name});
+            }
+            $res
+        }
+    });
+
+    return Twitter::API->new_with_traits(
+        traits              => 'RateLimiting',
+        consumer_key        => 'key',
+        consumer_secret     => 'secret',
+        access_token        => 'token',
+        access_token_secret => 'token-secret',
+        user_agent          => $user_agent,
+    );
+}
+
+describe RateLimiting => sub {
+    it 'should be unaffected if the rate limit is never hit' => sub {
+        my $client = new_client();
+        my $sleep = mock();
+
+        $sleep->expects('ping')->exactly(0);
+
+        $client->rate_limit_sleep_code(sub { $sleep->ping });
+
+        $client->get('foo');
+        $client->get('foo');
+        $client->get('foo');
+        $client->get('foo');
+
+        pass;
+    };
+
+    it 'should invoke the sleep callback if the rate limit is hit' => sub {
+        my $client = new_client(2);
+
+        my $n_calls = 0;
+
+        $client->rate_limit_sleep_code(sub { $n_calls++ });
+
+        $client->get('foo');
+        $client->get('foo');
+        is $n_calls, 0, 'sleep should not be called before the 3rd request';
+        $client->get('foo');
+        is $n_calls, 1, 'sleep should be called exactly once after the 3rd request';
+        $client->get('foo');
+        is $n_calls, 1, 'the rate limit should have reset for the 4th request';
+    };
+
+    it 'should not intercept any other 4xx errors' => sub {
+        my $client = new_client(2, [ 400, 'Unknown Error' ]);
+
+        my $n_calls = 0;
+
+        $client->rate_limit_sleep_code(sub { $n_calls++ });
+
+        $client->get('foo');
+        $client->get('foo');
+        like exception {
+            $client->get('foo');
+        }, qr/Unknown Error/;
+
+        is $n_calls, 0, 'sleep should not be called if a different 4xx error happens';
+    };
+
+    it 'should not intercept any 5xx errors' => sub {
+        my $client = new_client(2, [ 500, 'Internal Server Error' ]);
+
+        my $n_calls = 0;
+
+        $client->rate_limit_sleep_code(sub { $n_calls++ });
+
+        $client->get('foo');
+        $client->get('foo');
+        like exception {
+            $client->get('foo');
+        }, qr/Internal Server Error/;
+
+        is $n_calls, 0, 'sleep should not be called if a 5xx error happens';
+    };
+
+    it 'should be called with the correct amount of time to sleep' => sub {
+        my $reset_time = time + 900;
+
+        my $client = new_client(2, [
+            HTTP_TOO_MANY_REQUESTS, 'Rate Limit Exceeded',
+            'x-rate-limit-reset' => $reset_time,
+        ]);
+
+        my $sleep_amount;
+
+        $client->rate_limit_sleep_code(sub {
+            ( $sleep_amount ) = @_;
+        });
+
+        $client->get('foo');
+        $client->get('foo');
+        my $next_time = time + 1;
+        $client->get('foo');
+        is $sleep_amount, ($reset_time - $next_time), 'sleep should be called with the correct time interval';
+    };
+};
+
+runtests;


### PR DESCRIPTION
This trait, when added to a client, will transparently sleep the
required amount of time when a request exceeded a rate limit