### PR TITLE
Added new Direct Message APIs for migration from old ones.

### DIFF
--- a/lib/Twitter/API.pm
+++ b/lib/Twitter/API.pm
@@ -190,8 +190,8 @@ sub prepare_request {
             : $c->has_option('to_json')   ? $self->prepare_json_post($c)
             : $self->prepare_post($c)
         )
-        : $method eq 'GET' ? $self->prepare_get($c)
-        : croak "unexpected HTTP method: $_"
+        : $method eq 'GET' || $method eq 'DELETE' ? $self->prepare_method_urlonly($c)
+        : croak "unexpected HTTP method: $method"
     );
 }
 
@@ -224,7 +224,7 @@ sub prepare_post {
         Content => $self->encode_args_string($c->args);
 }
 
-sub prepare_get {
+sub prepare_method_urlonly {
     my ( $self, $c ) = @_;
 
     my $uri = URI->new($c->url);
@@ -232,7 +232,8 @@ sub prepare_get {
         $uri->query($encoded);
     }
 
-    GET $uri, %{ $c->headers };
+    my $methodsubname = 'HTTP::Request::Common::' . $c->http_method;
+    (\&$methodsubname)->($uri, %{ $c->headers });
 }
 
 sub add_authorization {

--- a/lib/Twitter/API/Trait/ApiMethods.pm
+++ b/lib/Twitter/API/Trait/ApiMethods.pm
@@ -1198,6 +1198,56 @@ sub upload_media {
 }
 alias upload => 'upload_media';
 
+=method direct_messages_events([ \%args ])
+
+L<https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/list-events.html>
+
+=cut
+
+sub direct_messages_events {
+    shift->request(get => 'direct_messages/events/list', @_);
+}
+
+=method show_direct_messages_event([ $id, ][ \%args ])
+
+L<https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/get-event>
+
+=cut
+
+sub show_direct_messages_event {
+    shift->request_with_pos_args(id => get => 'direct_messages/events/show', @_);
+}
+
+=method destroy_direct_messages_event([ $id, ][ \%args ])
+
+L<https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/delete-message-event>
+
+=cut
+
+sub destroy_direct_messages_event {
+    shift->request_with_pos_args(id => delete => 'direct_messages/events/destroy', @_);
+}
+
+=method new_direct_messages_event([ $text, [ $recipient_id, ]][ \%args ])
+
+L<https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/new-message>
+
+=cut
+
+sub new_direct_messages_event {
+    shift->request(post => 'direct_messages/events/new', {
+        -to_json => {
+            event => {
+                type => 'message_create',
+                message_create => {
+                    message_data => { text => shift },
+                    target => { recipient_id => shift },
+                }
+            },
+        }
+    }, @_);
+}
+
 1;
 
 =pod

--- a/t/trait/api-methods/direct-messages.t
+++ b/t/trait/api-methods/direct-messages.t
@@ -1,0 +1,63 @@
+#!perl
+use 5.14.1;
+use warnings;
+use Test::Spec;
+
+use Twitter::API;
+
+describe direct_messages => sub {
+    my $client;
+    my $is_stub_test;
+    my $new_message_id;
+    before each => sub {
+        $client = Twitter::API->new_with_traits(
+            traits              => 'ApiMethods',
+            consumer_key        => 'key',
+            consumer_secret     => 'secret',
+            access_token        => 'token',
+            access_token_secret => 'token-secret',
+        );
+        if ($client->consumer_key eq 'key') {
+            $client->stubs(send_request => sub { return });
+            $is_stub_test = 1;
+        }
+    };
+
+    it 'new_direct_messages_event' => sub {
+        my $user_id_str = $client->verify_credentials()->{id_str};
+        my $context = $client->new_direct_messages_event('test message ' . time, $user_id_str);
+        if ($is_stub_test) {
+            ok $context->http_request->method eq 'POST' && $context->http_request->uri =~ m'/direct_messages/events/new\.json$' && $context->http_request->content;
+            $new_message_id = 'dummy';
+        } else {
+            ok(exists $context->{event});
+            $new_message_id = $context->{event}->{id};
+        }
+    };
+    it 'direct_messages_events' => sub {
+        my $context = $client->direct_messages_events();
+        if ($is_stub_test) {
+            ok $context->http_request->method eq 'GET' && $context->http_request->uri =~ m'/direct_messages/events/list\.json$';
+        } else {
+            ok(exists $context->{events} && @{ $context->{events} } > 0);
+        }
+    };
+    it 'show_direct_messages_event' => sub {
+        my $context = $client->show_direct_messages_event($new_message_id);
+        if ($is_stub_test) {
+            ok $context->http_request->method eq 'GET' && $context->http_request->uri =~ m'/direct_messages/events/show\.json\?id=dummy$';
+        } else {
+            ok(exists $context->{event});
+        }
+    };
+    it 'destroy_direct_messages_event' => sub {
+        my $context = $client->destroy_direct_messages_event($new_message_id);
+        if ($is_stub_test) {
+            ok $context->http_request->method eq 'DELETE' && $context->http_request->uri =~ m'/direct_messages/events/destroy\.json\?id=dummy$';
+        } else {
+            ok($context eq '');
+        }
+    };
+};
+
+runtests;


### PR DESCRIPTION
Added new Direct Message APIs for migration from some APIs which will be deprecated on August 16th, 2018.

https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/guides/direct-message-migration.html