### PR TITLE
Simplify creating DMs with attachments

### DIFF
--- a/lib/Twitter/API/Trait/ApiMethods.pm
+++ b/lib/Twitter/API/Trait/ApiMethods.pm
@@ -1194,7 +1194,7 @@ sub destroy_direct_messages_event {
     shift->request_with_pos_args(id => delete => 'direct_messages/events/destroy', @_);
 }
 
-=method new_direct_messages_event([ $text, $recipient_id ] | [ \%event ])
+=method new_direct_messages_event([$text, $recipient_id ] | [ \%event ], [ \%args ])
 
 For simple usage, pass text and recipient ID:
 
@@ -1222,19 +1222,24 @@ L<https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/ap
 
 sub new_direct_messages_event {
     my $self = shift;
-    my $event = shift if ref $_[0];
-    my ( $text, $recipient_id ) = @_;
 
-    $event //= {
+    # The first argument is either an event hashref, or we'll create one with
+    # the first two arguments: text and recipient_id.
+    my $event = ref $_[0] ? shift : {
         type => 'message_create',
         message_create => {
-            message_data => { text => $text },
-            target => { recipient_id => $recipient_id },
+            message_data => { text => shift },
+            target => { recipient_id => shift },
         },
     };
 
+    # only synthetic args are appropriate, here, e.g.
+    # { -token => '...', -token_secret => '...' }
+    my $args = shift // {};
+
+
     $self->request(post => 'direct_messages/events/new', {
-        -to_json => { event => $event }
+        -to_json => { event => $event }, %$args
     });
 }
 

--- a/lib/Twitter/API/Trait/ApiMethods.pm
+++ b/lib/Twitter/API/Trait/ApiMethods.pm
@@ -68,15 +68,7 @@ sub collections {
     shift->request_with_pos_args(':ID', get => 'collections/list', @_);
 }
 
-=method direct_messages([ \%args ])
-
-L<https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/get-messages>
-
-=cut
-
-sub direct_messages {
-    shift->request(get => 'direct_messages', @_);
-}
+sub direct_messages { croak 'DEPRECATED - use direct_messages_events instead' }
 
 =method favorites([ \%args ])
 
@@ -506,20 +498,10 @@ L<https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/ap
 
 =cut
 
-sub sent_direct_messages {
-    shift->request(get => 'direct_messages/sent', @_);
-}
+sub sent_direct_messages { croak 'DEPRECATED - use direct_messages_events instead' }
 alias direct_messages_sent => 'sent_direct_messages';
 
-=method show_direct_message([ $id, ][ \%args ])
-
-L<https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/get-message>
-
-=cut
-
-sub show_direct_message {
-    shift->request_with_pos_args(id => get => 'direct_messages/show', @_);
-}
+sub show_direct_message { croak 'DEPRECATED - show_direct_messages_event instead' }
 
 =method show_friendship([ \%args ])
 
@@ -885,15 +867,7 @@ sub destroy_collection {
     shift->request_with_pos_args(id => post => 'collections/destroy', @_);
 }
 
-=method destroy_direct_message([ $id, ][ \%args ])
-
-L<https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/delete-message>
-
-=cut
-
-sub destroy_direct_message {
-    shift->request_with_pos_args(id => post => 'direct_messages/destroy', @_);
-}
+sub destroy_direct_message { croak 'DEPRECATED - use destroy_direct_messages_event instead' }
 
 =method destroy_favorite([ $id, ][ \%args ])
 
@@ -991,15 +965,7 @@ sub move_collection_entry {
         post => 'collections/entries/move', @_);
 }
 
-=method new_direct_message([ $text, [ $screen_name | $user_id, ]][ \%args ])
-
-L<https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/new-message>
-
-=cut
-
-sub new_direct_message {
-    shift->request_with_pos_args([ qw/text :ID/ ], post => 'direct_messages/new', @_);
-}
+sub new_direct_message { croak 'DEPRECATED - use new_direct_messages_event instead' }
 
 =method remove_collection_entry([ $id, [ $tweet_id, ]][ \%args ])
 

--- a/t/trait/api-methods/direct-messages.t
+++ b/t/trait/api-methods/direct-messages.t
@@ -46,6 +46,30 @@ describe direct_messages => sub {
             $new_message_id = $context->{event}->{id};
         }
     };
+    it 'new_direct_messages_event with synthetic args' => sub {
+        if ($is_stub_test) {
+            my $user_id_str = '666';
+            my $text = 'test message ' . time;
+            my $context = $client->new_direct_messages_event($text, $user_id_str, {
+                -token        => 'passed-token',
+                -token_secret => 'passed-secret',
+            });
+
+           ok $context->http_request->method eq 'POST'
+            && $context->http_request->uri =~ m'/direct_messages/events/new\.json$'
+            && eq_hash(decode_json($context->http_request->content), {
+                event => {
+                    type => 'message_create',
+                    message_create => {
+                        target => { recipient_id => $user_id_str },
+                        message_data => { text => $text },
+                    },
+                },
+            })
+            && $context->http_request->header('authorization')
+                =~ /oauth_token="passed-token"/;
+        }
+    };
     it 'new_direct_messages_event with event paylod' => sub {
         if ($is_stub_test) {
             my $event =  {

--- a/t/trait/api-methods/direct-messages.t
+++ b/t/trait/api-methods/direct-messages.t
@@ -2,6 +2,7 @@
 use 5.14.1;
 use warnings;
 use Test::Spec;
+use JSON::MaybeXS qw/decode_json/;
 
 use Twitter::API;
 
@@ -25,13 +26,46 @@ describe direct_messages => sub {
 
     it 'new_direct_messages_event' => sub {
         my $user_id_str = $client->verify_credentials()->{id_str};
-        my $context = $client->new_direct_messages_event('test message ' . time, $user_id_str);
+        my $text = 'test message ' . time;
+        my $context = $client->new_direct_messages_event($text, $user_id_str);
         if ($is_stub_test) {
-            ok $context->http_request->method eq 'POST' && $context->http_request->uri =~ m'/direct_messages/events/new\.json$' && $context->http_request->content;
+            ok $context->http_request->method eq 'POST'
+            && $context->http_request->uri =~ m'/direct_messages/events/new\.json$'
+            && eq_hash(decode_json($context->http_request->content), {
+                event => {
+                    type => 'message_create',
+                    message_create => {
+                        target => { recipient_id => $user_id_str },
+                        message_data => { text => $text },
+                    },
+                },
+            });
             $new_message_id = 'dummy';
         } else {
             ok(exists $context->{event});
             $new_message_id = $context->{event}->{id};
+        }
+    };
+    it 'new_direct_messages_event with event paylod' => sub {
+        if ($is_stub_test) {
+            my $event =  {
+                type => 'message_create',
+                message_create => {
+                    target => { recipient_id => 666 },
+                    message_data => {
+                        text => 'test message ' . time,
+                        attachment => {
+                            type  => 'media',
+                            media => { id => 1234 },
+                        },
+                    },
+                },
+            };
+            my $context = $client->new_direct_messages_event($event);
+            ok $context->http_request->method eq 'POST'
+            && $context->http_request->uri =~ m'/direct_messages/events/new\.json$'
+            && eq_hash(decode_json($context->http_request->content), { event => $event });
+            $new_message_id = 'dummy';
         }
     };
     it 'direct_messages_events' => sub {

--- a/t/trait/api-methods/net-twitter-compatibility.t
+++ b/t/trait/api-methods/net-twitter-compatibility.t
@@ -18,6 +18,11 @@ my %skip = map +($_ => 1), (
     'contributees',           # deprecated
     'contributors',           # deprecated
     'create_media_metadata',  # described incorrectly in Net::Twitter
+    'destroy_direct_message', # deprecated
+    'direct_messages',        # deprecated
+    'new_direct_message',     # deprecated
+    'sent_direct_messages',   # deprecated
+    'show_direct_message',    # deprecated
     'similar_places',         # no longer documented
     'update_delivery_device', # no longer documented
     'update_profile_colors',  # no longer documented
@@ -37,7 +42,6 @@ my %override_required = (
     destroy_block      => [ ':ID' ],
     report_spam        => [ ':ID' ],
     update_friendship  => [ ':ID' ],
-    new_direct_message => [ qw/text :ID/ ],
     create_mute        => [ ':ID' ],
     destroy_mute       => [ ':ID' ],
 );


### PR DESCRIPTION
I modified method `new_direct_messages_event` to take either the simple, positional text and recipient ID parameters, or a full event hashref. This will allow creation of more complex DMs with image attachments, for example.

For example:
```perl
    $client->new_direct_massages_event({
        type => 'message_create',
        message_create => {
            target => { recipient_id => $user_id },
            message_data => {
                text => $text,
                attachment => {
                    type  => 'media',
                    media => { id => $media->{id} },
                },
            },
        },
    });
```

I don't know if Twitter will ever add event types other than `message_create`. I'm allowing for that possibility here, though, so we don't get boxed in if they do. It seems reasonable to me, though to not require the outer event wrapper. The method name implies it will always take an event.

I also deprecated the old direct messages methods. They are no longer documented and they croak if called pointing users to the new DM methods.

Prior to this change, creating a DM with attached image required something like:
```perl
my $r = $client->post('direct_messages/events/new', {
    -to_json => {
        event => {
            type => 'message_create',
            message_create => {
                target => { recipient_id => $user_id },
                message_data => {
                    text => $text,
                    attachment => {
                        type  => 'media',
                        media => { id => $media_id },
                    },
                },
            },
        },
    },
});
```